### PR TITLE
Added org.wso2.carbon.tomcat.jndi.* to Tomcat Environment

### DIFF
--- a/modules/distribution/repository/conf/tomcat/as-classloading-environments.xml
+++ b/modules/distribution/repository/conf/tomcat/as-classloading-environments.xml
@@ -33,7 +33,7 @@
 
         <DelegatedEnvironment>
             <Name>Tomcat</Name>
-            <DelegatedPackages>javax.annotation.*,javax.ejb,javax.el,javax.persistence,javax.servlet.*,javax.xml,javax.xml.ws,org.apache.catalina.*,org.apache.coyote.*,org.apache.el.*,org.apache.jasper.*,org.apache.naming.*,org.apache.tomcat.*,com.sun.el.*</DelegatedPackages>
+            <DelegatedPackages>javax.annotation.*,javax.ejb,javax.el,javax.persistence,javax.servlet.*,javax.xml,javax.xml.ws,org.apache.catalina.*,org.apache.coyote.*,org.apache.el.*,org.apache.jasper.*,org.apache.naming.*,org.apache.tomcat.*,com.sun.el.*,org.wso2.carbon.tomcat.jndi.*</DelegatedPackages>
             <DelegatedResources>*,!META-INF/services/org.apache.webbeans.spi.plugins.OpenWebBeansPlugin,!META-INF/openwebbeans/openwebbeans.properties,!META-INF/standard-faces-config.xml,!META-INF/faces-config.xml</DelegatedResources>
         </DelegatedEnvironment>
 


### PR DESCRIPTION
When deploying booking-faces webapp it throws  
javax.naming.NoInitialContextException: Failed to create InitialContext using factory specified in hash table. [Root exception is java.lang.ClassNotFoundException: class org.wso2.carbon.tomcat.jndi.CarbonJavaURLContextFactory not found]
	at org.wso2.carbon.context.internal.CarbonContextDataHolder$CarbonInitialJNDIContextFactoryBuilder.createInitialContextFactory(CarbonContextDataHolder.java:491)
	at javax.naming.spi.NamingManager.getInitialContext(NamingManager.java:681)
	at javax.naming.InitialContext.getDefaultInitCtx(InitialContext.java:313)
