### PR TITLE
WSAS-2077 : enabling test case testChangePasswordOfCurrentUser()

### DIFF
--- a/modules/integration/tests-integration/tests/src/test/java/org/wso2/appserver/integration/tests/usermgt/UserManagementWithAdminUserTestCase.java
+++ b/modules/integration/tests-integration/tests/src/test/java/org/wso2/appserver/integration/tests/usermgt/UserManagementWithAdminUserTestCase.java
@@ -186,17 +186,16 @@ public class UserManagementWithAdminUserTestCase extends ASIntegrationTest {
 		}
 	}
 
-        //TODO: Fix this test case - WSAS-2077
-	@Test(groups = "wso2.as", description = "Change password of current user defined in automation.xml", enabled = false)
+	@Test(groups = "wso2.as", description = "Change password of current user defined in automation.xml")
 	public void testChangePasswordOfCurrentUser() throws Exception {
 		String oldPassword = userInfo.getPassword();
 		String newPassword = "admin123";
 		String loggedInUsername = "admin";
-		userManagementClient.changePasswordByUser(oldPassword, newPassword);
 		// Try to login with new password
 		if (userMode == TestUserMode.TENANT_ADMIN) {
 			loggedInUsername += "@" + asServer.getContextTenant().getDomain();
 		}
+		userManagementClient.changePasswordByUser(loggedInUsername, oldPassword, newPassword);
 		loginLogoutClient = new LoginLogoutClient(asServer);
 		assertNotNull(loginLogoutClient
 				              .login(loggedInUsername, newPassword, asServer.getInstance().getHosts().get("default")),
@@ -216,7 +215,7 @@ public class UserManagementWithAdminUserTestCase extends ASIntegrationTest {
 		             "User able to login to system using old password");
 
 		//Revert back to old password
-		userManagementClient.changePasswordByUser(newPassword, oldPassword);
+		userManagementClient.changePasswordByUser(loggedInUsername, newPassword, oldPassword);
 		loginLogoutClient = new LoginLogoutClient(asServer);
 		assertNotNull(loginLogoutClient
 				              .login(loggedInUsername, oldPassword, asServer.getInstance().getHosts().get("default")),


### PR DESCRIPTION
This test case was enabled after fixes to integration test utils introduced with https://github.com/wso2/carbon-platform-integration-utils/commit/8e0504b00bf4d85ecf6ac70eb8ce118e74d9986f 