### PR TITLE
Fixing a JavaDoc issue related to appserver-utils module on Windows platform.

### DIFF
--- a/modules/appserver-utils/src/main/java/org/wso2/appserver/Constants.java
+++ b/modules/appserver-utils/src/main/java/org/wso2/appserver/Constants.java
@@ -26,12 +26,12 @@ public final class Constants {
      */
 
     /**
-     * Namespace for wso2as.xml file XML content
+     * Namespace for wso2as.xml file XML content.
      */
     public static final String APP_SERVER_CONFIGURATION_NAMESPACE = "http://wso2.org/2016/wso2as";
 
     /**
-     * Namespace for wso2as-web.xml file XML content
+     * Namespace for wso2as-web.xml file XML content.
      */
     public static final String WEBAPP_DESCRIPTOR_NAMESPACE = "http://wso2.org/2016/wso2as-web";
 
@@ -40,19 +40,19 @@ public final class Constants {
      */
 
     /**
-     * WSO2 Application Server descriptor file name
+     * WSO2 Application Server descriptor file name.
      */
     public static final String APP_SERVER_DESCRIPTOR = "wso2as.xml";
     /**
-     * WSO2 Application Server descriptor XML schema file name
+     * WSO2 Application Server descriptor XML schema file name.
      */
     public static final String APP_SERVER_DESCRIPTOR_SCHEMA = "wso2as.xsd";
     /**
-     * WSO2 Application Server context level descriptor file name
+     * WSO2 Application Server context level descriptor file name.
      */
     public static final String WEBAPP_DESCRIPTOR = "wso2as-web.xml";
     /**
-     * WSO2 Application Server context level descriptor schema file name
+     * WSO2 Application Server context level descriptor schema file name.
      */
     public static final String WEBAPP_DESCRIPTOR_SCHEMA = "wso2as-web.xsd";
 
@@ -61,15 +61,15 @@ public final class Constants {
      */
 
     /**
-     * Apache Tomcat configuration base directory identifier
+     * Apache Tomcat configuration base directory identifier.
      */
     public static final String TOMCAT_CONFIGURATION_DIRECTORY = "conf";
     /**
-     * WSO2 Application Server configuration base directory identifier
+     * WSO2 Application Server configuration base directory identifier.
      */
     public static final String APP_SERVER_CONFIGURATION_DIRECTORY = "wso2";
     /**
-     * Web application specific resource folder identifier
+     * Web application specific resource folder identifier.
      */
     public static final String WEBAPP_RESOURCE_FOLDER = "WEB-INF";
 

--- a/modules/appserver-utils/src/test/java/org/wso2/appserver/AppServerConfigurationTest.java
+++ b/modules/appserver-utils/src/test/java/org/wso2/appserver/AppServerConfigurationTest.java
@@ -23,7 +23,7 @@ import org.wso2.appserver.configuration.server.ClassLoaderEnvironments;
 import org.wso2.appserver.configuration.server.SSOConfiguration;
 import org.wso2.appserver.configuration.server.SecurityConfiguration;
 import org.wso2.appserver.configuration.server.StatsPublisherConfiguration;
-import org.wso2.appserver.exceptions.ApplicationServerException;
+import org.wso2.appserver.exceptions.ApplicationServerConfigurationException;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -40,19 +40,15 @@ import java.util.List;
 public class AppServerConfigurationTest {
     @Test(description = "Loads the XML file content of the WSO2 App Server specific server level configuration " +
             "descriptor")
-    public void loadObjectFromFilePathTest() {
+    public void loadObjectFromFilePathTest() throws IOException, ApplicationServerConfigurationException {
         Path xmlSource = Paths.
                 get(TestConstants.BUILD_DIRECTORY, TestConstants.TEST_RESOURCE_FOLDER, TestConstants.SAMPLE_XML_FILE);
         Path xmlSchema = Paths.
                 get(TestConstants.BUILD_DIRECTORY, TestConstants.TEST_RESOURCE_FOLDER, TestConstants.SAMPLE_XSD_FILE);
-        try {
-            AppServerConfiguration actual = Utils.
-                    getUnmarshalledObject(Files.newInputStream(xmlSource), xmlSchema, AppServerConfiguration.class);
-            AppServerConfiguration expected = generateDefault();
-            Assert.assertTrue(compare(actual, expected));
-        } catch (ApplicationServerException | IOException e) {
-            Assert.fail();
-        }
+        AppServerConfiguration actual = Utils.
+                getUnmarshalledObject(Files.newInputStream(xmlSource), xmlSchema, AppServerConfiguration.class);
+        AppServerConfiguration expected = generateDefault();
+        Assert.assertTrue(compare(actual, expected));
     }
 
     protected static AppServerConfiguration generateDefault() {

--- a/modules/appserver-utils/src/test/java/org/wso2/appserver/AppServerConfigurationTest.java
+++ b/modules/appserver-utils/src/test/java/org/wso2/appserver/AppServerConfigurationTest.java
@@ -38,7 +38,8 @@ import java.util.List;
  * @since 6.0.0
  */
 public class AppServerConfigurationTest {
-    @Test
+    @Test(description = "Loads the XML file content of the WSO2 App Server specific server level configuration " +
+            "descriptor")
     public void loadObjectFromFilePathTest() {
         Path xmlSource = Paths.
                 get(TestConstants.BUILD_DIRECTORY, TestConstants.TEST_RESOURCE_FOLDER, TestConstants.SAMPLE_XML_FILE);

--- a/modules/appserver-utils/src/test/java/org/wso2/appserver/AppServerWebAppConfigurationTest.java
+++ b/modules/appserver-utils/src/test/java/org/wso2/appserver/AppServerWebAppConfigurationTest.java
@@ -21,7 +21,7 @@ import org.wso2.appserver.configuration.context.AppServerWebAppConfiguration;
 import org.wso2.appserver.configuration.context.ClassLoaderConfiguration;
 import org.wso2.appserver.configuration.context.SSOConfiguration;
 import org.wso2.appserver.configuration.listeners.Utils;
-import org.wso2.appserver.exceptions.ApplicationServerException;
+import org.wso2.appserver.exceptions.ApplicationServerConfigurationException;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -35,24 +35,19 @@ import java.util.List;
  */
 public class AppServerWebAppConfigurationTest {
     @Test(description = "Loads the XML file content of the WSO2 App Server specific webapp descriptor")
-    public void loadObjectFromFilePath() {
+    public void loadObjectFromFilePath() throws ApplicationServerConfigurationException {
         Path xmlSchema = Paths.get(TestConstants.BUILD_DIRECTORY, TestConstants.TEST_RESOURCE_FOLDER,
                 TestConstants.WEBAPP_DESCRIPTOR_XSD_FILE);
         Path parent = Paths.
                 get(TestConstants.BUILD_DIRECTORY, TestConstants.TEST_RESOURCE_FOLDER, TestConstants.PARENT_DESCRIPTOR);
         Path child = Paths.
                 get(TestConstants.BUILD_DIRECTORY, TestConstants.TEST_RESOURCE_FOLDER, TestConstants.CHILD_DESCRIPTOR);
-
-        try {
-            AppServerWebAppConfiguration parentConfig = Utils.
-                    getUnmarshalledObject(parent, xmlSchema, AppServerWebAppConfiguration.class);
-            AppServerWebAppConfiguration childConfig = Utils.
-                    getUnmarshalledObject(child, xmlSchema, AppServerWebAppConfiguration.class);
-            parentConfig.merge(childConfig);
-            Assert.assertTrue(compare(parentConfig, prepareDefault()));
-        } catch (ApplicationServerException e) {
-            Assert.fail();
-        }
+        AppServerWebAppConfiguration parentConfig = Utils.
+                getUnmarshalledObject(parent, xmlSchema, AppServerWebAppConfiguration.class);
+        AppServerWebAppConfiguration childConfig = Utils.
+                getUnmarshalledObject(child, xmlSchema, AppServerWebAppConfiguration.class);
+        parentConfig.merge(childConfig);
+        Assert.assertTrue(compare(parentConfig, prepareDefault()));
     }
 
     private static AppServerWebAppConfiguration prepareDefault() {

--- a/modules/appserver-utils/src/test/java/org/wso2/appserver/AppServerWebAppConfigurationTest.java
+++ b/modules/appserver-utils/src/test/java/org/wso2/appserver/AppServerWebAppConfigurationTest.java
@@ -34,7 +34,7 @@ import java.util.List;
  * @since 6.0.0
  */
 public class AppServerWebAppConfigurationTest {
-    @Test
+    @Test(description = "Loads the XML file content of the WSO2 App Server specific webapp descriptor")
     public void loadObjectFromFilePath() {
         Path xmlSchema = Paths.get(TestConstants.BUILD_DIRECTORY, TestConstants.TEST_RESOURCE_FOLDER,
                 TestConstants.WEBAPP_DESCRIPTOR_XSD_FILE);

--- a/modules/appserver-utils/src/test/java/org/wso2/appserver/PathUtilTest.java
+++ b/modules/appserver-utils/src/test/java/org/wso2/appserver/PathUtilTest.java
@@ -37,20 +37,20 @@ public class PathUtilTest {
         System.setProperty(Globals.CATALINA_BASE_PROP, CATALINA_BASE.toString());
     }
 
-    @Test
+    @Test(description = "Loads a file path representation of the CATALINA_BASE")
     public void getCatalinaBaseTest() {
         Path actual = PathUtils.getCatalinaBase();
         Assert.assertEquals(actual.toString(), CATALINA_BASE.toString());
     }
 
-    @Test
+    @Test(description = "Loads a file path representation of the Tomcat config-base")
     public void getCatalinaConfigurationHomeTest() {
         Path expected = Paths.get(CATALINA_BASE.toString(), Constants.TOMCAT_CONFIGURATION_DIRECTORY);
         Path actual = PathUtils.getCatalinaConfigurationBase();
         Assert.assertEquals(actual.toString(), expected.toString());
     }
 
-    @Test
+    @Test(description = "Loads a file path representation of the WSO2 specific config-base")
     public void getWSO2ConfigurationHomeTest() {
         Path expected = Paths.get(CATALINA_BASE.toString(), Constants.TOMCAT_CONFIGURATION_DIRECTORY,
                 Constants.APP_SERVER_CONFIGURATION_DIRECTORY);

--- a/modules/appserver-utils/src/test/java/org/wso2/appserver/UtilsTest.java
+++ b/modules/appserver-utils/src/test/java/org/wso2/appserver/UtilsTest.java
@@ -33,7 +33,8 @@ import java.nio.file.Paths;
  * @since 6.0.0
  */
 public class UtilsTest {
-    @Test(expectedExceptions = { ApplicationServerConfigurationException.class })
+    @Test(description = "Attempts to load the XML file content with a non-existent XML schema file for validation",
+            expectedExceptions = { ApplicationServerConfigurationException.class })
     public void loadObjectFromNonExistentSchemaAsPath() throws ApplicationServerConfigurationException {
         Path xmlSource = Paths.
                 get(TestConstants.BUILD_DIRECTORY, TestConstants.TEST_RESOURCE_FOLDER, TestConstants.SAMPLE_XML_FILE);
@@ -42,14 +43,16 @@ public class UtilsTest {
         Utils.getUnmarshalledObject(xmlSource, xmlSchema, AppServerConfiguration.class);
     }
 
-    @Test(expectedExceptions = { ApplicationServerConfigurationException.class })
+    @Test(description = "Uses an invalid XML schema file for validation",
+            expectedExceptions = { ApplicationServerConfigurationException.class })
     public void invalidSchemaTest() throws ApplicationServerException {
         Path xmlSchema = Paths.
                 get(TestConstants.BUILD_DIRECTORY, TestConstants.TEST_RESOURCE_FOLDER, TestConstants.INVALID_XSD_FILE);
         Utils.getXMLUnmarshaller(xmlSchema, AppServerConfiguration.class);
     }
 
-    @Test(expectedExceptions = { ApplicationServerConfigurationException.class })
+    @Test(description = "Attempts to load content from a file path source with invalid XML syntax",
+            expectedExceptions = { ApplicationServerConfigurationException.class })
     public void loadObjectFromInvalidFileTest() throws ApplicationServerException {
         Path xmlSource = Paths.
                 get(TestConstants.BUILD_DIRECTORY, TestConstants.TEST_RESOURCE_FOLDER, TestConstants.INVALID_XML_FILE);
@@ -58,7 +61,8 @@ public class UtilsTest {
         Utils.getUnmarshalledObject(xmlSource, xmlSchema, AppServerConfiguration.class);
     }
 
-    @Test(expectedExceptions = { ApplicationServerConfigurationException.class })
+    @Test(description = "Attempts to load content from a file input stream with invalid XML syntax",
+            expectedExceptions = { ApplicationServerConfigurationException.class })
     public void loadObjectFromInvalidInputStreamTest() throws ApplicationServerException {
         Path xmlSource = Paths.
                 get(TestConstants.BUILD_DIRECTORY, TestConstants.TEST_RESOURCE_FOLDER, TestConstants.INVALID_XML_FILE);


### PR DESCRIPTION
Fixing a JavaDoc issue related to app-server-utils module on Windows platform. 

Please note that Windows build is currently failing due to a maven-antrun-plugin issue (file path varying on different platforms due to hard-coding of file path values) under integration tests which may be changed in the future.